### PR TITLE
feat: deepcopy 함수 구현 및 ES6 데이터 타입(Set, Map, Symbol) 지원

### DIFF
--- a/__test__/deepcopy.test.js
+++ b/__test__/deepcopy.test.js
@@ -1,74 +1,108 @@
 const deepcopy = require("../deepcopy");
 
-describe("deepcopy 함수 - 얕은 복사 테스트", () => {
-  test("number 타입을 복사한다.", () => {
-    const original = 15;
-    const copy = original;
+describe("deepcopy 함수 테스트", () => {
+  describe("원시 타입(Primitive Types) 복사", () => {
+    test("number 타입을 복사한다.", () => {
+      const original = 15;
+      const copy = original;
 
-    expect(copy).toBe(original);
+      expect(copy).toBe(original);
+    });
+
+    test("string 타입을 복사한다.", () => {
+      const original = "hello";
+      const copy = original;
+
+      expect(copy).toBe(original);
+    });
+
+    test("boolean 타입을 복사한다.", () => {
+      const original = true;
+      const copy = original;
+
+      expect(copy).toBe(original);
+    });
+
+    test("null을 복사한다.", () => {
+      const original = null;
+      const copy = original;
+
+      expect(copy).toBeNull();
+    });
+
+    test("undefined를 복사한다.", () => {
+      const original = undefined;
+      const copy = original;
+
+      expect(copy).toBeUndefined();
+    });
   });
 
-  test("string 타입을 복사한다.", () => {
-    const original = "hello";
-    const copy = original;
+  describe("참조 타입(reference Types) 깊은 복사", () => {
+    test("1차원 객체를 깊은 복사한다.", () => {
+      const original = { a: 1, b: 2 };
+      const copy = deepcopy(original);
 
-    expect(copy).toBe(original);
+      expect(copy).toEqual(original); // 객체의 값과 구조가 같은지 확인
+      expect(copy).not.toBe(original); // 객체의 참조가 다른지 확인
+    });
+
+    test("중첩 객체를 깊은 복사한다.", () => {
+      const original = { a: 1, b: { c: [5, 3, 7], d: 3 } };
+      const copy = deepcopy(original);
+
+      expect(copy).toEqual(original); // 객체의 값과 구조가 같은지 확인
+      expect(copy).not.toBe(original); // 객체의 참조가 다른지 확인
+
+      // 복사된 중첩 객체의 값이 일치하는지 확인
+      expect(copy.b).toEqual(original.b);
+      expect(copy.b).not.toBe(original.b); // 중첩 객체의 참조가 다른지 확인
+    });
+
+    test("배열을 깊은 복사한다.", () => {
+      const original = [1, 2, { a: { c: "d" }, b: 4 }];
+      const copy = deepcopy(original);
+
+      expect(copy).toEqual(original); // 배열의 값과 구조가 같은지 확인
+      expect(copy).not.toBe(original); // 배열의 참조가 다른지 확인
+
+      // 배열의 각 요소가 깊은 복사되어 있는지 확인
+      expect(copy[2]).toEqual(original[2]);
+      expect(copy[2]).not.toBe(original[2]); // 중첩 객체의 참조가 다른지 확인
+      expect(copy[2].a).toEqual(original[2].a);
+      expect(copy[2].a).not.toBe(original[2].a); // 중첩 객체의 내부 객체 참조가 다른지 확인
+    });
   });
 
-  test("boolean 타입을 복사한다.", () => {
-    const original = true;
-    const copy = original;
+  describe("ES6 타입 복사 (Map, Set, Symbol)", () => {
+    test("Map 객체를 복사하면 원본을 수정해도 복사본은 영향을 받지 않는다.", () => {
+      const original = new Map();
+      original.set("key1", "value1");
+      original.set("key2", { key3: 11 });
 
-    expect(copy).toBe(original);
-  });
+      const copy = deepcopy(original);
+      original.get("key2").key3 = "changed";
 
-  test("null을 복사한다.", () => {
-    const original = null;
-    const copy = original;
+      expect(copy.get("key2").key3).toBe(11);
+      expect(copy).not.toBe(original);
+    });
 
-    expect(copy).toBeNull();
-  });
+    test("Set 객체를 복사하면 원본을 수정해도 복사본은 영향을 받지 않는다.", () => {
+      const original = new Set([1, 2, { a: 3 }]);
 
-  test("undefined를 복사한다.", () => {
-    const original = undefined;
-    const copy = original;
+      const copy = deepcopy(original);
+      [...original][2].a = 99;
 
-    expect(copy).toBeUndefined();
-  });
-});
+      expect([...copy][2].a).toBe(3);
+      expect(copy).not.toBe(original);
+    });
 
-describe("deepcopy 함수 - 깊은 복사 테스트 ", () => {
-  test("1차원 객체를 깊은 복사한다.", () => {
-    const original = { a: 1, b: 2 };
-    const copy = deepcopy(original);
+    test("Symbol 값을 복사하면 동일한 Symbol을 반환한다.", () => {
+      const originalSymbol = Symbol("id");
 
-    expect(copy).toEqual(original); // 객체의 값과 구조가 같은지 확인
-    expect(copy).not.toBe(original); // 객체의 참조가 다른지 확인
-  });
+      const copy = deepcopy(originalSymbol);
 
-  test("중첩 객체를 깊은 복사한다.", () => {
-    const original = { a: 1, b: { c: [5, 3, 7], d: 3 } };
-    const copy = deepcopy(original);
-
-    expect(copy).toEqual(original); // 객체의 값과 구조가 같은지 확인
-    expect(copy).not.toBe(original); // 객체의 참조가 다른지 확인
-
-    // 복사된 중첩 객체의 값이 일치하는지 확인
-    expect(copy.b).toEqual(original.b);
-    expect(copy.b).not.toBe(original.b); // 중첩 객체의 참조가 다른지 확인
-  });
-
-  test("배열을 깊은 복사한다.", () => {
-    const original = [1, 2, { a: { c: "d" }, b: 4 }];
-    const copy = deepcopy(original);
-
-    expect(copy).toEqual(original); // 배열의 값과 구조가 같은지 확인
-    expect(copy).not.toBe(original); // 배열의 참조가 다른지 확인
-
-    // 배열의 각 요소가 깊은 복사되어 있는지 확인
-    expect(copy[2]).toEqual(original[2]);
-    expect(copy[2]).not.toBe(original[2]); // 중첩 객체의 참조가 다른지 확인
-    expect(copy[2].a).toEqual(original[2].a);
-    expect(copy[2].a).not.toBe(original[2].a); // 중첩 객체의 내부 객체 참조가 다른지 확인
+      expect(copy).toBe(originalSymbol);
+    });
   });
 });

--- a/__test__/deepcopy.test.js
+++ b/__test__/deepcopy.test.js
@@ -4,35 +4,35 @@ describe("deepcopy 함수 테스트", () => {
   describe("원시 타입(Primitive Types) 복사", () => {
     test("number 타입을 복사한다.", () => {
       const original = 15;
-      const copy = original;
+      const copy = deepcopy(original);
 
       expect(copy).toBe(original);
     });
 
     test("string 타입을 복사한다.", () => {
       const original = "hello";
-      const copy = original;
+      const copy = deepcopy(original);
 
       expect(copy).toBe(original);
     });
 
     test("boolean 타입을 복사한다.", () => {
       const original = true;
-      const copy = original;
+      const copy = deepcopy(original);
 
       expect(copy).toBe(original);
     });
 
     test("null을 복사한다.", () => {
       const original = null;
-      const copy = original;
+      const copy = deepcopy(original);
 
       expect(copy).toBeNull();
     });
 
     test("undefined를 복사한다.", () => {
       const original = undefined;
-      const copy = original;
+      const copy = deepcopy(original);
 
       expect(copy).toBeUndefined();
     });

--- a/deepcopy.js
+++ b/deepcopy.js
@@ -7,6 +7,22 @@ function deepcopy(value) {
     return value.map(deepcopy);
   }
 
+  if (value instanceof Set) {
+    const setCopy = new Set();
+    value.forEach((item) => {
+      setCopy.add(deepcopy(item));
+    });
+    return setCopy;
+  }
+
+  if (value instanceof Map) {
+    const mapCopy = new Map();
+    value.forEach((val, key) => {
+      mapCopy.set(key, deepcopy(val));
+    });
+    return mapCopy;
+  }
+
   const objCopy = {};
   Object.keys(value).forEach((key) => {
     objCopy[key] = deepcopy(value[key]);

--- a/deepcopy.js
+++ b/deepcopy.js
@@ -2,7 +2,16 @@ function deepcopy(value) {
   if (value === null || typeof value !== "object") {
     return value;
   }
-  throw new Error("얕은 복사만 구현되어 있음");
+
+  if (Array.isArray(value)) {
+    return value.map(deepcopy);
+  }
+
+  const objCopy = {};
+  Object.keys(value).forEach((key) => {
+    objCopy[key] = deepcopy(value[key]);
+  });
+  return objCopy;
 }
 
 module.exports = deepcopy;

--- a/deepcopy.js
+++ b/deepcopy.js
@@ -1,0 +1,8 @@
+function deepcopy(value) {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  throw new Error("얕은 복사만 구현되어 있음");
+}
+
+module.exports = deepcopy;


### PR DESCRIPTION
## 개요
`deepcopy`함수 구현하면서 ES6에서 도입된 데이터 타입(`Set`, `Map`, `Symbol`)의 깊은 복사 기능도 추가하였습니다. 

## 구현한 사항
* deepcopy 함수 기본 구현
* Set, Map 타입 지원 및 단위 테스트 작성
* Symbol 테스트 코드 추가

## 연관된 이슈
* Closes #3 #4 